### PR TITLE
two minor updates to data loading functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,37 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    paths:
+      - .github/workflows/**
+      - datawrangler/**
+      - tests/**
+      - MANIFEST.in
+      - Makefile
+      - requirements.txt
+      - requirements_dev.txt
+      - setup.cfg
+      - setup.py
+      - tox.ini
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - datawrangler/**
+      - tests/**
+      - MANIFEST.in
+      - Makefile
+      - requirements.txt
+      - requirements_dev.txt
+      - setup.cfg
+      - setup.py
+      - tox.ini
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    # only run on pull requests between forks to avoid duplicate runs with 'push' event
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/datawrangler/io/io.py
+++ b/datawrangler/io/io.py
@@ -93,10 +93,15 @@ def load(x, dtype=None, **kwargs):
             if 'allow_pickle' not in helper_kwargs.keys():
                 helper_kwargs['allow_pickle'] = True
             data = np.load(fname, **helper_kwargs)
-            if type(data) is dict:
-                if len(data.keys()) == 1:
-                    return data[list(data.keys())[0]]
-            return data
+            try:
+                if type(data) is dict:
+                    if len(data.keys()) == 1:
+                        return data[list(data.keys())[0]]
+                return data
+            except Exception:
+                if isinstance(data, np.lib.npyio.NpzFile):
+                    data.close()
+                raise
         else:
             dtype = get_extension(fname)
             if dtype == 'txt':

--- a/datawrangler/zoo/text.py
+++ b/datawrangler/zoo/text.py
@@ -162,11 +162,15 @@ def get_corpus(dataset_name='wikipedia', config_name='20200501.en'):
 
     if dataset_name in corpora.keys():
         print(f'loading corpus: {dataset_name}', end='...')
-        corpus = load(corpora[dataset_name], dtype='numpy')['corpus']
-        print('done!')
-
-        preloaded_corpora[key] = corpus
-        return corpus
+        data = load(corpora[dataset_name], dtype='numpy')
+        try:
+            corpus = data['corpus']
+            print('done!')
+            preloaded_corpora[key] = corpus
+            return corpus
+        finally:
+            # ensure NpzFile is closed
+            data.close()
 
     # Hugging-Face Corpus
     try:
@@ -291,7 +295,7 @@ def apply_text_model(x, text, *args, mode='fit_transform', return_model=False, *
         return transformed_text
     elif is_hugging_face_model(model):
         warnings.simplefilter('ignore')
-        
+
         if mode == 'fit':  # do nothing-- just return the un-transformed text and original model
             if return_model:
                 return text, {'model': model, 'args': args, 'kwargs': kwargs}

--- a/datawrangler/zoo/text.py
+++ b/datawrangler/zoo/text.py
@@ -179,7 +179,7 @@ def get_corpus(dataset_name='wikipedia', config_name='20200501.en'):
         raise RuntimeError(f'Corpus not found: {dataset_name}.  Available corpora: {", ".join(list_datasets())}')
     except ValueError:
         raise RuntimeError(f'Configuration for {dataset_name} corpus not found: {config_name}. '
-                           f'Available configurations: {", ".join(get_dataset_config_names(data_name))}')
+                           f'Available configurations: {", ".join(get_dataset_config_names(dataset_name))}')
 
     corpus = []
     content_keys = ['text', 'content']


### PR DESCRIPTION
1. **explicitly close `numpy.lib.npyio.NpzFile` instance, handle errors**
   
   From the [numpy.load docs](https://numpy.org/devdocs/reference/generated/numpy.load.html):
   > For .npz files, the returned instance of NpzFile class must be closed to avoid leaking file descriptors.

   This probably isn't a big deal since Python generally closes file descriptors automatically when their reference counts drops to 0,  but there are a few scenarios where this doesn't happen (an exception is raised, running in `pdb` or an IDE debugger, etc.) and this change will handle most or all of them without adding any real overhead. The cleanest way to do this would just be to wrap the reset of `datawrangler.io.io.load` after the call to `numpy.load()` in a `try`/`finally` block and explicitly close the descriptor when the function returns, but this isn't possible because its fields (e.g., `"corpus"`) need to be accessible in outer scopes. I didn't comb through the code too carefully, so there may be other calls to `datawrangler.io.io.load` that would benefit from updates similar to `datawrangler.zoo.text.get_corpus`, but again, I don't think this is a high-priority issue.

2. **change `data_name` ➡️ `dataset_name` in `datawrangler.zoo.text.get_corpus`**

   There was a reference to a variable named `data_name` that didn't seem to exist anywhere -- my guess is that the `dataset_name` parameter was at some point renamed from `data_name`, and this one use of it wasn't updated. I looked through the git blame, and the bug has existed since the [`hypertools_revamp` notebook](https://github.com/jeremymanning/hypertools/blob/dev/dev/hypertools_revamp.ipynb) this function was added from. If `data_name` should actually be something other than `dataset_name`, let me know!